### PR TITLE
navbar fixed

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -17,14 +17,16 @@
         <li class="nav-item">
           <%= link_to "Messages", "#", class: "nav-link" %>
         </li>
-        <li class="dropdown">
-          <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { 'bs-toggle': "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
-          <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-            <%= link_to "Action", "#", class: "dropdown-item" %>
-            <%= link_to "Another action", "#", class: "dropdown-item" %>
-            <%= link_to "Log out", destroy_user_session_path, data: { turbo_method: :delete }, class: "dropdown-item" %>
-          </div>
-        </li>
+
+  <li class="dropdown">
+  <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+  <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
+  <%= link_to "Action", "#", class: "dropdown-item" %>
+  <%= link_to "Another action", "#", class: "dropdown-item" %>
+  <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
+  </div>
+    </li>
+
       <% else %>
         <li class="nav-item">
           <%= link_to "Login", new_user_session_path, class: "nav-link" %>


### PR DESCRIPTION
consertei o menu dropdown do navbar com css
voltei aqui para informar que nao havia ido o meu css corrigido, fiz o pull mas deu redundancia de branch. 
Favor poderia substituir no navbar esse trecho

<li class="dropdown">
  <%= image_tag "https://kitt.lewagon.com/placeholder/users/ssaunier", class: "avatar dropdown-toggle", id: "navbarDropdown", data: { bs_toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
  <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
  <%= link_to "Action", "#", class: "dropdown-item" %>
  <%= link_to "Another action", "#", class: "dropdown-item" %>
  <%= link_to "Log out", destroy_user_session_path, data: {turbo_method: :delete}, class: "dropdown-item" %>
  </div>
    </li>